### PR TITLE
GNOME automatic display scaling

### DIFF
--- a/packages/gpdpocket-gnome-config/files/gnome/01scale
+++ b/packages/gpdpocket-gnome-config/files/gnome/01scale
@@ -1,3 +1,3 @@
 [org/gnome/desktop/interface]
-scaling-factor=uint32 1
+scaling-factor=uint32 0
 text-scaling-factor=uint32 1


### PR DESCRIPTION
Tell GNOME to detect display DPI automatically and apply appropriate scaling. This will apply 2x scaling for all displays under Xorg, and apply 2x scaling only to the built in display under Wayland.